### PR TITLE
Cancelling distributed query

### DIFF
--- a/src/Protocols/Identify1.cs
+++ b/src/Protocols/Identify1.cs
@@ -101,6 +101,8 @@ namespace PeerTalk.Protocols
                         .Where(a => a != null)
                         .ToList();
                 }
+                if (remote.Addresses.Count() == 0)
+                    log.Warn($"No listen address for {remote}");
             }
 
             // TODO: Verify the Peer ID

--- a/src/Routing/Dht1.cs
+++ b/src/Routing/Dht1.cs
@@ -237,6 +237,8 @@ namespace PeerTalk.Routing
                 })
                 .ToArray();
 
+            if (log.IsDebugEnabled)
+                log.Debug($"returning {response.CloserPeers.Length} closer peers");
             return response;
         }
 

--- a/src/Routing/Dht1.cs
+++ b/src/Routing/Dht1.cs
@@ -47,6 +47,12 @@ namespace PeerTalk.Routing
         /// </value>
         public int CloserPeerCount { get; set; } = 20;
 
+        /// <summary>
+        ///   Raised when the DHT is stopped.
+        /// </summary>
+        /// <seealso cref="StopAsync"/>
+        public event EventHandler Stopped;
+
         /// <inheritdoc />
         public override string ToString()
         {
@@ -114,6 +120,7 @@ namespace PeerTalk.Routing
             Swarm.RemoveProtocol(this);
             Swarm.PeerDiscovered -= Swarm_PeerDiscovered;
 
+            Stopped?.Invoke(this, EventArgs.Empty);
             return Task.CompletedTask;
         }
 

--- a/src/Routing/DistributedQuery.cs
+++ b/src/Routing/DistributedQuery.cs
@@ -99,6 +99,7 @@ namespace PeerTalk.Routing
             log.Debug($"Q{Id} run {QueryType} {QueryKey}");
 
             runningQuery = CancellationTokenSource.CreateLinkedTokenSource(cancel);
+            Dht.Stopped += OnDhtStopped;
             queryMessage = new DhtMessage
             {
                 Type = QueryType,
@@ -116,7 +117,17 @@ namespace PeerTalk.Routing
             {
                 // eat it
             }
+            finally
+            {
+                Dht.Stopped -= OnDhtStopped;
+            }
             log.Debug($"Q{Id} found {Answers.Count} answers, visited {visited.Count} peers");
+        }
+
+        private void OnDhtStopped(object sender, EventArgs e)
+        {
+            log.Debug($"Q{Id} cancelled because DHT stopped.");
+            runningQuery.Cancel();
         }
 
         /// <summary>

--- a/src/Routing/DistributedQuery.cs
+++ b/src/Routing/DistributedQuery.cs
@@ -54,7 +54,7 @@ namespace PeerTalk.Routing
         ///   The number of answers needed.
         /// </summary>
         /// <remarks>
-        ///   When the numbers <see cref="Answers"/> recaches this limit
+        ///   When the numbers <see cref="Answers"/> reaches this limit
         ///   the <see cref="RunAsync">running query</see> will stop.
         /// </remarks>
         public int AnswersNeeded { get; set; } = 1;

--- a/src/Routing/DistributedQuery.cs
+++ b/src/Routing/DistributedQuery.cs
@@ -29,7 +29,7 @@ namespace PeerTalk.Routing
         /// <summary>
         ///   The maximum time spent on waiting for an answer from a peer.
         /// </summary>
-        static TimeSpan askTime = TimeSpan.FromSeconds(20);
+        static readonly TimeSpan askTime = TimeSpan.FromSeconds(20);
 
         CancellationTokenSource runningQuery;
         List<Peer> visited = new List<Peer>();

--- a/src/Swarm.cs
+++ b/src/Swarm.cs
@@ -517,7 +517,7 @@ namespace PeerTalk
             // TODO: filter out self addresses and others.
             if (possibleAddresses.Length == 0)
             {
-                throw new Exception($"{remote} has no known addresses.");
+                throw new Exception($"{remote} has no known address.");
             }
 
             // Try the various addresses in parallel.  The first one to complete wins.

--- a/src/Swarm.cs
+++ b/src/Swarm.cs
@@ -41,7 +41,7 @@ namespace PeerTalk
         /// <summary>
         ///   Added to connection protocols when needed.
         /// </summary>
-        Plaintext1 plaintext1 = new Plaintext1();
+        readonly Plaintext1 plaintext1 = new Plaintext1();
 
         Peer localPeer;
 

--- a/test/Routing/Dht1Test.cs
+++ b/test/Routing/Dht1Test.cs
@@ -231,5 +231,19 @@ namespace PeerTalk.Routing
             }
         }
 
+        [TestMethod]
+        public async Task QueryIsCancelled_WhenDhtStops()
+        {
+            var unknownPeer = new MultiHash("QmdpwjdB94eNm2Lcvp9JqoCxswo3AKQqjLuNZyLixmCxxx");
+            var swarm = new Swarm { LocalPeer = self };
+            await swarm.RegisterPeerAsync("/ip4/178.62.158.247/tcp/4001/ipfs/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd");
+            await swarm.RegisterPeerAsync("/ip4/104.236.76.40/tcp/4001/ipfs/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64");
+            var dht = new Dht1 { Swarm = swarm };
+            await dht.StartAsync();
+            var task = dht.FindPeerAsync(unknownPeer);
+            await Task.Delay(400);
+            await dht.StopAsync();
+        }
+
     }
 }

--- a/test/Routing/Dht1Test.cs
+++ b/test/Routing/Dht1Test.cs
@@ -29,6 +29,18 @@ namespace PeerTalk.Routing
         };
 
         [TestMethod]
+        public async Task StoppedEventRaised()
+        {
+            var swarm = new Swarm { LocalPeer = self };
+            var dht = new Dht1 { Swarm = swarm };
+            bool stopped = false;
+            dht.Stopped += (s, e) => { stopped = true;  };
+            await dht.StartAsync();
+            await dht.StopAsync();
+            Assert.IsTrue(stopped);
+        }
+
+        [TestMethod]
         public async Task SeedsRoutingTableFromSwarm()
         {
             var swarm = new Swarm { LocalPeer = self };

--- a/test/Routing/DistributedQueryTests.cs
+++ b/test/Routing/DistributedQueryTests.cs
@@ -14,7 +14,10 @@ namespace PeerTalk.Routing
         [TestMethod]
         public async Task Cancelling()
         {
-            var dquery = new DistributedQuery<Peer>();
+            var dquery = new DistributedQuery<Peer>
+            {
+                Dht = new Dht1()
+            };
             var cts = new CancellationTokenSource();
             cts.Cancel();
             await dquery.RunAsync(cts.Token);
@@ -28,5 +31,6 @@ namespace PeerTalk.Routing
             var q2 = new DistributedQuery<Peer>();
             Assert.AreNotEqual(q1.Id, q2.Id);
         }
+
     }
 }

--- a/test/SwarmTest.cs
+++ b/test/SwarmTest.cs
@@ -12,9 +12,9 @@ namespace PeerTalk
     [TestClass]
     public class SwarmTest
     {
-        MultiAddress mars = "/ip4/10.1.10.10/tcp/29087/ipfs/QmSoLMeWqB7YGVLJN3pNLQpmmEk35v6wYtsMGLzSr5QBU3";
-        MultiAddress venus = "/ip4/104.236.76.40/tcp/4001/ipfs/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64";
-        MultiAddress earth = "/ip4/178.62.158.247/tcp/4001/ipfs/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd";
+        readonly MultiAddress mars = "/ip4/10.1.10.10/tcp/29087/ipfs/QmSoLMeWqB7YGVLJN3pNLQpmmEk35v6wYtsMGLzSr5QBU3";
+        readonly MultiAddress venus = "/ip4/104.236.76.40/tcp/4001/ipfs/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64";
+        readonly MultiAddress earth = "/ip4/178.62.158.247/tcp/4001/ipfs/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd";
         Peer self = new Peer
         {
             AgentVersion = "self",


### PR DESCRIPTION
When the DHT is stopped, all distributed queries should be cancelled.