### PR TITLE
fix(Identify1): multiaddress ends with peer ID

### DIFF
--- a/src/PeerTalk.csproj
+++ b/src/PeerTalk.csproj
@@ -51,7 +51,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ipfs.Core" Version="0.52.1" />
+    <PackageReference Include="Ipfs.Core" Version="0.52.2" />
     <PackageReference Include="Makaretu.Dns.Multicast" Version="0.24.0" />
     <PackageReference Include="Makaretu.KBucket" Version="0.5.0" />
     <PackageReference Include="Nito.AsyncEx" Version="5.0.0" />

--- a/test/Protocols/Identify1Test.cs
+++ b/test/Protocols/Identify1Test.cs
@@ -13,7 +13,6 @@ namespace PeerTalk.Protocols
     public class Identitfy1Test
     {
         [TestMethod]
-        [Ignore("Not ready")]
         public async Task RoundTrip()
         {
             var peerA = new Peer
@@ -36,18 +35,57 @@ namespace PeerTalk.Protocols
                 Stream = ms
             };
 
+            // Generate identify msg.
             var identify = new Identify1();
             await identify.ProcessMessageAsync(connection, ms);
 
+            // Process identify msg.
             ms.Position = 0;
-            await identify.ProcessMessageAsync(connection, ms);
+            await identify.UpdateRemotePeerAsync(peerB, ms, CancellationToken.None);
+
             Assert.AreEqual(peerA.AgentVersion, peerB.AgentVersion);
             Assert.AreEqual(peerA.Id, peerB.Id);
             Assert.AreEqual(peerA.ProtocolVersion, peerB.ProtocolVersion);
             Assert.AreEqual(peerA.PublicKey, peerB.PublicKey);
-            Assert.AreEqual(peerA.Addresses.Count(), peerB.Addresses.Count());
-            Assert.AreEqual(peerA.Addresses.First(), peerB.Addresses.First());
+            CollectionAssert.AreEqual(peerA.Addresses.ToArray(), peerB.Addresses.ToArray());
         }
 
+        [TestMethod]
+        public async Task InvalidPublicKey()
+        {
+            var peerA = new Peer
+            {
+                Addresses = new MultiAddress[]
+                {
+                    "/ip4/127.0.0.1/tcp/4002/ipfs/QmXFX2P5ammdmXQgfqGkfswtEVFsZUJ5KeHRXQYCTdiTAb"
+                },
+                AgentVersion = "agent/1",
+                Id = "QmXFX2P5ammdmXQgfqGkfswtEVFsZUJ5KeHRXQYCTdiTAb",
+                ProtocolVersion = "protocol/1",
+                PublicKey = "BADSpgIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCfBYU9c0n28u02N/XCJY8yIsRqRVO5Zw+6kDHCremt2flHT4AaWnwGLAG9YyQJbRTvWN9nW2LK7Pv3uoIlvUSTnZEP0SXB5oZeqtxUdi6tuvcyqTIfsUSanLQucYITq8Qw3IMBzk+KpWNm98g9A/Xy30MkUS8mrBIO9pHmIZa55fvclDkTvLxjnGWA2avaBfJvHgMSTu0D2CQcmJrvwyKMhLCSIbQewZd2V7vc6gtxbRovKlrIwDTmDBXbfjbLljOuzg2yBLyYxXlozO9blpttbnOpU4kTspUVJXglmjsv7YSIJS3UKt3544l/srHbqlwC5CgOgjlwNfYPadO8kmBfAgMBAAE="
+            };
+            var peerB = new Peer
+            {
+                Id = peerA.Id
+            };
+            var ms = new MemoryStream();
+            var connection = new PeerConnection
+            {
+                LocalPeer = peerA,
+                RemotePeer = peerB,
+                Stream = ms
+            };
+
+            // Generate identify msg.
+            var identify = new Identify1();
+            await identify.ProcessMessageAsync(connection, ms);
+
+            // Process identify msg.
+            ms.Position = 0;
+            ExceptionAssert.Throws<InvalidDataException>(() =>
+            {
+                identify.UpdateRemotePeerAsync(peerB, ms, CancellationToken.None).Wait();
+            });
+        }
     }
 }

--- a/test/Protocols/Identify1Test.cs
+++ b/test/Protocols/Identify1Test.cs
@@ -87,5 +87,43 @@ namespace PeerTalk.Protocols
                 identify.UpdateRemotePeerAsync(peerB, ms, CancellationToken.None).Wait();
             });
         }
+
+        [TestMethod]
+        public async Task MustHavePublicKey()
+        {
+            var peerA = new Peer
+            {
+                Addresses = new MultiAddress[]
+                {
+                    "/ip4/127.0.0.1/tcp/4002/ipfs/QmXFX2P5ammdmXQgfqGkfswtEVFsZUJ5KeHRXQYCTdiTAb"
+                },
+                AgentVersion = "agent/1",
+                Id = "QmXFX2P5ammdmXQgfqGkfswtEVFsZUJ5KeHRXQYCTdiTAb",
+                ProtocolVersion = "protocol/1",
+                PublicKey = ""
+            };
+            var peerB = new Peer
+            {
+                Id = peerA.Id
+            };
+            var ms = new MemoryStream();
+            var connection = new PeerConnection
+            {
+                LocalPeer = peerA,
+                RemotePeer = peerB,
+                Stream = ms
+            };
+
+            // Generate identify msg.
+            var identify = new Identify1();
+            await identify.ProcessMessageAsync(connection, ms);
+
+            // Process identify msg.
+            ms.Position = 0;
+            ExceptionAssert.Throws<InvalidDataException>(() =>
+            {
+                identify.UpdateRemotePeerAsync(peerB, ms, CancellationToken.None).Wait();
+            });
+        }
     }
 }

--- a/test/SwarmTest.cs
+++ b/test/SwarmTest.cs
@@ -280,6 +280,67 @@ namespace PeerTalk
         }
 
         [TestMethod]
+        public async Task RemotePeer_Contains_ConnectedAddress1()
+        {
+            var peerB = new Peer
+            {
+                AgentVersion = "peerB",
+                Id = "QmdpwjdB94eNm2Lcvp9JqoCxswo3AKQqjLuNZyLixmCM1h",
+                PublicKey = "CAASXjBcMA0GCSqGSIb3DQEBAQUAA0sAMEgCQQDlTSgVLprWaXfmxDr92DJE1FP0wOexhulPqXSTsNh5ot6j+UiuMgwb0shSPKzLx9AuTolCGhnwpTBYHVhFoBErAgMBAAE="
+            };
+            var swarmB = new Swarm { LocalPeer = peerB };
+            await swarmB.StartAsync();
+            var peerBAddress = await swarmB.StartListeningAsync("/ip4/0.0.0.0/tcp/0");
+
+            var swarm = new Swarm { LocalPeer = self };
+            await swarm.StartAsync();
+            try
+            {
+                var connection = await swarm.ConnectAsync(peerBAddress);
+                var remote = connection.RemotePeer;
+                Assert.AreEqual(remote.ConnectedAddress, peerBAddress);
+                CollectionAssert.Contains(remote.Addresses.ToArray(), peerBAddress);
+            }
+            finally
+            {
+                await swarm.StopAsync();
+                await swarmB.StopAsync();
+            }
+        }
+
+        [TestMethod]
+        public async Task RemotePeer_Contains_ConnectedAddress2()
+        {
+            var peerB = new Peer
+            {
+                AgentVersion = "peerB",
+                Id = "QmdpwjdB94eNm2Lcvp9JqoCxswo3AKQqjLuNZyLixmCM1h",
+                PublicKey = "CAASXjBcMA0GCSqGSIb3DQEBAQUAA0sAMEgCQQDlTSgVLprWaXfmxDr92DJE1FP0wOexhulPqXSTsNh5ot6j+UiuMgwb0shSPKzLx9AuTolCGhnwpTBYHVhFoBErAgMBAAE="
+            };
+            var swarmB = new Swarm { LocalPeer = peerB };
+            await swarmB.StartAsync();
+            var peerBAddress = await swarmB.StartListeningAsync("/ip4/0.0.0.0/tcp/0");
+            var peerBPort = peerBAddress.Protocols[1].Value;
+            Assert.IsTrue(peerB.Addresses.Count() > 0);
+
+            var swarm = new Swarm { LocalPeer = self };
+            await swarm.StartAsync();
+            try
+            {
+                MultiAddress ma = $"/ip4/127.0.0.100/tcp/{peerBPort}/ipfs/{peerB.Id}";
+                var connection = await swarm.ConnectAsync(ma);
+                var remote = connection.RemotePeer;
+                Assert.AreEqual(remote.ConnectedAddress, ma);
+                CollectionAssert.Contains(remote.Addresses.ToArray(), ma);
+            }
+            finally
+            {
+                await swarm.StopAsync();
+                await swarmB.StopAsync();
+            }
+        }
+
+        [TestMethod]
         public async Task Connect_CancelsOnStop()
         {
             var swarm = new Swarm { LocalPeer = self };

--- a/test/SwarmTest.cs
+++ b/test/SwarmTest.cs
@@ -224,6 +224,7 @@ namespace PeerTalk
 
             var swarm = new Swarm { LocalPeer = self };
             await swarm.StartAsync();
+            await swarm.StartListeningAsync("/ip4/127.0.0.1/tcp/0");
             try
             {
                 var remotePeer = (await swarm.ConnectAsync(peerBAddress)).RemotePeer;


### PR DESCRIPTION
Fixing multiaddress inconsistencies.  All `Peer.Addresses` must end with the peer ID.  See #42