### PR TITLE
Basic Implementation of Noise

### DIFF
--- a/src/AutoDialer.cs
+++ b/src/AutoDialer.cs
@@ -154,9 +154,9 @@ namespace PeerTalk
             {
                 await swarm.ConnectAsync(peer).ConfigureAwait(false);
             }
-            catch (Exception)
+            catch (Exception e)
             {
-                log.Warn($"Failed to dial {peer}");
+                log.Warn($"Failed to dial {peer}: {e.Message}", e);
             }
             finally
             {

--- a/src/AutoDialer.cs
+++ b/src/AutoDialer.cs
@@ -103,9 +103,10 @@ namespace PeerTalk
                 {
                     await swarm.ConnectAsync(peer).ConfigureAwait(false);
                 }
-                catch(Exception)
+                catch(Exception e)
                 {
-                    log.Warn($"Failed to dial {peer}");
+                    
+                    log.Warn($"Failed to dial {peer}: {e.Message}");
                 }
                 finally
                 {

--- a/src/Cryptography/Key.cs
+++ b/src/Cryptography/Key.cs
@@ -91,7 +91,7 @@ namespace PeerTalk.Cryptography
                     key.signingAlgorithmName = RsaSigningAlgorithmName;
                     break;
                 case KeyType.Ed25519:
-                    key.publicKey = PublicKeyFactory.CreateKey(ipfsKey.Data);
+                    key.publicKey = new Ed25519PublicKeyParameters(ipfsKey.Data, 0);
                     key.signingAlgorithmName = Ed25519SigningAlgorithmName;
                     break;
                 case KeyType.Secp256k1:

--- a/src/Discovery/MdnsJs.cs
+++ b/src/Discovery/MdnsJs.cs
@@ -77,9 +77,14 @@ namespace PeerTalk.Discovery
             foreach (var name in peerNames)
             {
                 var id = name.Labels[0];
-                var srv = message.Answers
+                var srvList = message.Answers
                     .OfType<SRVRecord>()
-                    .First(r => r.Name == name);
+                    .Where(r => r.Name == name);
+                if(srvList.Count() == 0)
+                {
+                    continue;
+                }
+                var srv = srvList.First();
                 var aRecords = message.Answers
                     .OfType<ARecord>()
                     .Where(a => a.Name == name || a.Name == srv.Target);

--- a/src/Multiplex/Substream.cs
+++ b/src/Multiplex/Substream.cs
@@ -174,6 +174,7 @@ namespace PeerTalk.Multiplex
         /// <inheritdoc />
         public override async Task FlushAsync(CancellationToken cancel)
         {
+            if (outStream == null) throw new ObjectDisposedException(nameof(Substream));
             if (outStream.Length == 0)
                 return;
 
@@ -198,12 +199,14 @@ namespace PeerTalk.Multiplex
         /// <inheritdoc />
         public override void Write(byte[] buffer, int offset, int count)
         {
+            if (outStream == null) throw new ObjectDisposedException(nameof(Substream));
             outStream.Write(buffer, offset, count);
         }
 
         /// <inheritdoc />
         public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
+            if (outStream == null) throw new ObjectDisposedException(nameof(Substream));
             return outStream.WriteAsync(buffer, offset, count, cancellationToken);
         }
 

--- a/src/Multiplex/Substream.cs
+++ b/src/Multiplex/Substream.cs
@@ -45,7 +45,7 @@ namespace PeerTalk.Multiplex
         /// <value>
         ///   The session initiator allocates odd IDs and the session receiver allocates even IDs.
         /// </value>
-        public long Id;
+        public UInt64 Id;
         
         /// <summary>
         ///   A name for the stream.

--- a/src/Multiplex/SubstreamId.cs
+++ b/src/Multiplex/SubstreamId.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace PeerTalk.Multiplex
+{
+    internal struct SubstreamId
+    {
+        public bool Initiator; // Whether we initiated the stream, id's can be used by both the near and remote end as seperated streams
+        public UInt64 Id; // Max 2^60-1
+
+        public SubstreamId(bool initiator, UInt64 id)
+        {
+            Initiator = initiator;
+            Id = id;
+        }
+
+        public override string ToString()
+        {
+            return (Initiator ? "l" : "r") + Id.ToString();
+        }
+    }
+}

--- a/src/PeerConnection.cs
+++ b/src/PeerConnection.cs
@@ -211,12 +211,7 @@ namespace PeerTalk
             await EstablishProtocolAsync("/multistream/", cancel).ConfigureAwait(false);
             await EstablishProtocolAsync("/mplex/", cancel).ConfigureAwait(false);
 
-            var muxer = new Muxer
-            {
-                Channel = Stream,
-                Initiator = true,
-                Connection = this
-            };
+            var muxer = new Muxer(Stream, this);
             muxer.SubstreamCreated += (s, e) => _ = ReadMessagesAsync(e, CancellationToken.None);
             this.MuxerEstablished.SetResult(muxer);
 

--- a/src/PeerTalk.csproj
+++ b/src/PeerTalk.csproj
@@ -56,6 +56,7 @@
     <PackageReference Include="Makaretu.Dns.Multicast" Version="0.25.0" />
     <PackageReference Include="Makaretu.KBucket" Version="0.5.0" />
     <PackageReference Include="Nito.AsyncEx" Version="5.0.0" />
+    <PackageReference Include="Noise.NET" Version="1.0.0" />
     <PackageReference Include="protobuf-net" Version="2.4.0" />
     <PackageReference Include="semver" Version="2.0.4" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.9.0" />

--- a/src/PeerTalk.csproj
+++ b/src/PeerTalk.csproj
@@ -60,7 +60,7 @@
     <PackageReference Include="protobuf-net" Version="2.4.0" />
     <PackageReference Include="semver" Version="2.0.4" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.9.0" />
-    <PackageReference Include="Portable.BouncyCastle" Version="1.8.5" />
+    <PackageReference Include="Portable.BouncyCastle" Version="1.8.10" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19270-01" PrivateAssets="All" />

--- a/src/Protocols/Mplex67.cs
+++ b/src/Protocols/Mplex67.cs
@@ -36,12 +36,7 @@ namespace PeerTalk.Protocols
         public async Task ProcessMessageAsync(PeerConnection connection, Stream stream, CancellationToken cancel = default(CancellationToken))
         {
             log.Debug("start processing requests from " + connection.RemoteAddress);
-            var muxer = new Muxer
-            {
-                Channel = stream,
-                Connection = connection,
-                Receiver = true
-            };
+            var muxer = new Muxer(stream, connection);
             muxer.SubstreamCreated += (s, e) => _ = connection.ReadMessagesAsync(e, CancellationToken.None);
 
             // Attach muxer to the connection.  It now becomes the message reader.

--- a/src/Protocols/ProtocolRegistry.cs
+++ b/src/Protocols/ProtocolRegistry.cs
@@ -24,7 +24,7 @@ namespace PeerTalk.Protocols
         {
             Protocols = new Dictionary<string, Func<IPeerProtocol>>();
             Register<Multistream1>();
-            Register<SecureCommunication.Noise>();
+            Register<SecureCommunication.Noise.Noise>();
             Register<SecureCommunication.Secio1>();
             Register<Plaintext1>();
             Register<Identify1>();

--- a/src/Protocols/ProtocolRegistry.cs
+++ b/src/Protocols/ProtocolRegistry.cs
@@ -24,6 +24,7 @@ namespace PeerTalk.Protocols
         {
             Protocols = new Dictionary<string, Func<IPeerProtocol>>();
             Register<Multistream1>();
+            Register<SecureCommunication.Noise>();
             Register<SecureCommunication.Secio1>();
             Register<Plaintext1>();
             Register<Identify1>();

--- a/src/Protocols/VersionedName.cs
+++ b/src/Protocols/VersionedName.cs
@@ -28,7 +28,14 @@ namespace PeerTalk.Protocols
         /// <inheritdoc />
         public override string ToString()
         {
-            return $"/{Name}/{Version}";
+            if (Version != null)
+            {
+                return $"/{Name}/{Version}";
+            }
+            else
+            {
+                return $"/{Name}";
+            }
         }
 
         /// <summary>
@@ -41,8 +48,8 @@ namespace PeerTalk.Protocols
             var parts = s.Split('/').Where(p => p.Length > 0).ToArray();
             return new VersionedName
             {
-                Name = string.Join("/", parts, 0, parts.Length - 1),
-                Version = SemVersion.Parse(parts[parts.Length - 1])
+                Name = string.Join("/", parts, 0, parts.Length > 1 ? parts.Length - 1 : 1),
+                Version = parts.Length > 1 ? SemVersion.Parse(parts[parts.Length - 1]) : null
             };
         }
 
@@ -95,7 +102,7 @@ namespace PeerTalk.Protocols
         public int CompareTo(VersionedName that)
         {
             if (that == null) return 1;
-            if (this.Name == that.Name) return this.Version.CompareTo(that.Version);
+            if (this.Name == that.Name) return this.Version == null ? -1 : this.Version.CompareTo(that.Version);
             return this.Name.CompareTo(that.Name);
         }
     }

--- a/src/SecureCommunication/Noise/Noise.cs
+++ b/src/SecureCommunication/Noise/Noise.cs
@@ -1,0 +1,176 @@
+﻿using Common.Logging;
+using Ipfs;
+using Ipfs.Registry;
+using Noise;
+using Org.BouncyCastle.Security;
+using PeerTalk.Cryptography;
+using PeerTalk.Protocols;
+using ProtoBuf;
+using Semver;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PeerTalk.SecureCommunication
+{
+    /// <summary>
+    ///   Creates a secure connection with a peer.
+    /// </summary>
+    public class Noise : IEncryptionProtocol
+    {
+        static ILog log = LogManager.GetLogger(typeof(Noise));
+
+        /// <inheritdoc />
+        public string Name { get; } = "noise";
+
+        /// <inheritdoc />
+        public SemVersion Version { get; } = new SemVersion(1, 0);
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return $"/{Name}";
+        }
+
+        //private static string payloadSigPrefix = "noise-libp2p-static-key:";
+
+        /// <inheritdoc />
+        public async Task ProcessMessageAsync(PeerConnection connection, Stream stream, CancellationToken cancel = default(CancellationToken))
+        {
+            await EncryptAsync(connection, cancel).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public async Task<Stream> EncryptAsync(PeerConnection connection, CancellationToken cancel = default(CancellationToken))
+        {
+            if (connection.IsIncoming)
+            {
+                throw new NotImplementedException("Incoming Noise Encryption Handshakes not implemented");
+            }
+
+            log.Info($"Setting up noise protocol for {connection.RemotePeer.Id}");
+
+            var stream = connection.Stream;
+            var localPeer = connection.LocalPeer;
+            connection.RemotePeer = connection.RemotePeer ?? new Peer();
+            var remotePeer = connection.RemotePeer;
+
+            var protocol = new Protocol(
+              HandshakePattern.XX,
+              CipherFunction.ChaChaPoly,
+              HashFunction.Sha256,
+              PatternModifiers.None
+            );
+
+            var psk = new byte[32];
+
+            // Generate a random 32-byte pre-shared secret key.
+            using (var random = RandomNumberGenerator.Create())
+            {
+                random.GetBytes(psk);
+            }
+
+            try
+            {
+                using (var kp = KeyPair.Generate())
+                {
+                    var buffer = new byte[Protocol.MaxMessageLength];
+                    var readbuffer = new byte[Protocol.MaxMessageLength];
+
+                    using (var state = protocol.Create(initiator: !connection.IsIncoming, s: kp.PrivateKey))
+                    {
+                        if (!connection.IsIncoming)
+                        {
+
+                            log.Info($"Sending Noise Handshake {connection.RemotePeer.Id}");
+
+                            var (bytesWritten, _, _) = state.WriteMessage(null, buffer);
+                            await WriteStreamMessageAsync(stream, buffer, bytesWritten);
+
+                            log.Info($"Waiting For Noise Handshake {connection.RemotePeer.Id}");
+
+                            // Receive the second handshake message from the server.
+                            var received = await ReadStreamMessageAsync(stream, buffer, Protocol.MaxMessageLength);
+                            var (_, _, transport) = state.ReadMessage(new ReadOnlySpan<byte>(buffer, 0, received), readbuffer);
+
+                            log.Info($"Noise Handshake Done {connection.RemotePeer.Id}");
+                        }
+                    }
+                }
+            } catch (Exception e)
+            {
+                log.Error($"Something failed {e.Message}", e);
+            }
+
+            await Task.Yield();
+
+            return new System.IO.MemoryStream();//This should be the encrypted stream;
+        }
+
+        /**
+         * Writes a message to the stream and prefixes it with the message length
+         */
+        private static async Task WriteStreamMessageAsync(Stream stream, byte[] buffer, int bytes)
+        {
+            if (bytes > UInt16.MaxValue)
+            {
+                throw new ArgumentOutOfRangeException("Message size exceeds uint16 bytes");
+            }
+
+            var prefix = BitConverter.GetBytes((UInt16)bytes);
+            //We Want Big Endian
+            if (BitConverter.IsLittleEndian)
+                Array.Reverse(prefix);
+
+            await stream.WriteAsync(prefix, 0, 2);
+
+            await stream.WriteAsync(buffer, 0, bytes);
+            await stream.FlushAsync().ConfigureAwait(false);
+        }
+
+        /**
+         * Reads a message from the stream which is prefixed with the message length
+         */
+        private static async Task<int> ReadStreamMessageAsync(Stream stream, byte[] buffer, UInt16 bufferSize)
+        {
+            var prefix = new byte[2];
+
+            if (await stream.ReadAsync(prefix, 0, 1) == 0)
+            {
+                throw new Exception("Connection Closed");
+            }
+            if (await stream.ReadAsync(prefix, 1, 1) == 0)
+            {
+                throw new Exception("Connection Closed");
+            }
+
+            //We Want Big Endian
+            if (BitConverter.IsLittleEndian)
+                Array.Reverse(prefix);
+            var messageSize = BitConverter.ToUInt16(prefix, 0);
+
+            if (bufferSize < messageSize)
+            {
+                throw new Exception($"Recieved message ({messageSize}) larger than buffer ({bufferSize})");
+            }
+
+            var readTotal = 0;
+            while( messageSize > readTotal )
+            {
+                var read = await stream.ReadAsync(buffer, readTotal, messageSize - readTotal);
+                if (read == 0)
+                {
+                    throw new Exception("Connection Closed Mid-read");
+                }
+                readTotal += read;
+            }
+
+            return readTotal;
+        }
+    }
+}

--- a/src/SecureCommunication/Noise/Noise.cs
+++ b/src/SecureCommunication/Noise/Noise.cs
@@ -240,7 +240,6 @@ namespace PeerTalk.SecureCommunication.Noise
             }
 
             var peerStaticKey = state.RemoteStaticPublicKey;
-            log.Debug($"Identity {remoteId} Keylength: {payload.IdentityKey.Length}");
             try
             {
                 var peerIdentityKey = Key.CreatePublicKeyFromIpfs(payload.IdentityKey);

--- a/src/SecureCommunication/Noise/NoiseMessages.cs
+++ b/src/SecureCommunication/Noise/NoiseMessages.cs
@@ -1,0 +1,30 @@
+﻿using ProtoBuf;
+
+/*
+syntax = "proto3";
+package pb;
+
+message NoiseHandshakePayload {
+	bytes identity_key = 1;
+	bytes identity_sig = 2;
+	bytes data = 3;
+}
+*/
+
+namespace PeerTalk.SecureCommunication.Noise
+{
+    [ProtoContract]
+    class NoiseHandshakePayload
+    {
+        #pragma warning disable 0649
+        [ProtoMember(1)]
+        public byte[] IdentityKey;
+
+        [ProtoMember(2)]
+        public byte[] IdentitySig;
+
+        [ProtoMember(3)]
+        public byte[] Data;
+        #pragma warning restore 0649
+    }
+}

--- a/src/SecureCommunication/Noise/NoiseStream.cs
+++ b/src/SecureCommunication/Noise/NoiseStream.cs
@@ -1,0 +1,236 @@
+﻿
+
+using Common.Logging;
+using Noise;
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PeerTalk.SecureCommunication.Noise
+{
+    /// <summary>
+ ///   Stream wrapper that communicates using Noise
+ /// </summary>
+    public class NoiseStream : Stream
+    {
+        static ILog log = LogManager.GetLogger(typeof(NoiseStream));
+
+        private Transport transport;
+        private Stream stream;
+
+        private byte[] inBlock;
+        private int inBlockOffset;
+        MemoryStream outStream = new MemoryStream();
+
+        /// <summary>
+        ///   Stream wrapper that communicates using Noise
+        /// </summary>
+        /// <param name="transport">
+        ///   Noise transport state
+        /// </param>
+        /// <param name="stream">
+        ///   The backing stream this communicates on
+        /// </param>
+        public NoiseStream(Transport transport, Stream stream)
+        {
+            this.transport = transport;
+            this.stream = stream;
+        }
+
+        /// <inheritdoc />
+        public override bool CanRead => stream.CanRead;
+
+        /// <inheritdoc />
+        public override bool CanSeek => false;
+
+        /// <inheritdoc />
+        public override bool CanWrite => stream.CanRead;
+
+        /// <inheritdoc />
+        public override bool CanTimeout => false;
+
+        /// <inheritdoc />
+        public override long Length => throw new NotSupportedException();
+
+        /// <inheritdoc />
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        /// <inheritdoc />
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <inheritdoc />
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <inheritdoc />
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+#pragma warning disable VSTHRD002 
+            return ReadAsync(buffer, offset, count).GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002 
+        }
+
+        /// <inheritdoc />
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            int total = 0;
+            while (count > 0)
+            {
+                // Does the current packet have some unread data?
+                if (inBlock != null && inBlockOffset < inBlock.Length)
+                {
+                    var n = Math.Min(inBlock.Length - inBlockOffset, count);
+                    Array.Copy(inBlock, inBlockOffset, buffer, offset, n);
+                    total += n;
+                    count -= n;
+                    offset += n;
+                    inBlockOffset += n;
+                }
+                // Otherwise, wait for a new block of data.
+                else
+                {
+                    inBlock = await ReadPacketAsync(cancellationToken);
+                    inBlockOffset = 0;
+                }
+            }
+
+            return total;
+        }
+
+        /// <summary>
+        ///   Read an encrypted and signed packet.
+        /// </summary>
+        /// <returns>
+        ///   The plain text as an array of bytes.
+        /// </returns>
+        /// <remarks>
+        ///   A packet consists of a [uint32 length of packet | encrypted body | hmac signature of encrypted body].
+        /// </remarks>
+        async Task<byte[]> ReadPacketAsync(CancellationToken cancel)
+        {
+            var prefix = new byte[2];
+
+            if (await stream.ReadAsync(prefix, 0, 1, cancel) == 0)
+            {
+                throw new Exception("Connection Closed");
+            }
+            if (await stream.ReadAsync(prefix, 1, 1, cancel) == 0)
+            {
+                throw new Exception("Connection Closed");
+            }
+
+            //We Want Big Endian
+            if (BitConverter.IsLittleEndian)
+                Array.Reverse(prefix);
+            var messageSize = BitConverter.ToUInt16(prefix, 0);
+
+            var buffer = new byte[messageSize];
+
+            var readTotal = 0;
+            while (messageSize > readTotal)
+            {
+                var read = await stream.ReadAsync(buffer, readTotal, messageSize - readTotal, cancel);
+                if (read == 0)
+                {
+                    throw new Exception("Connection Closed Mid-read");
+                }
+                readTotal += read;
+            }
+
+            var plaintextbuffer = new byte[messageSize];
+
+            //Do that pesky decrypt thing
+            var plaintextBytes = transport.ReadMessage(buffer, plaintextbuffer);
+
+
+            log.Debug($"Recieved via Noise {messageSize} bytes");
+
+            //This is really inefficient but gets the job done
+            return new ReadOnlySpan<byte>(plaintextbuffer, 0, plaintextBytes).ToArray();
+        }
+
+        /// <inheritdoc />
+        public override void Flush()
+        {
+#pragma warning disable VSTHRD002 
+            FlushAsync().GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002 
+        }
+
+        /// <inheritdoc />
+        public override async Task FlushAsync(CancellationToken cancel)
+        {
+            if (outStream.Length == 0)
+                return;
+
+            var data = outStream.ToArray();  // plain text
+            outStream.SetLength(0);
+            var dataOffset = 0;
+
+            // We can't send more than 2^16 (64k) bytes in one message so we have to chunk.
+            while (dataOffset < data.Length)
+            {
+                const int TagSize = 16;
+                var chunksize = Math.Min(data.Length - dataOffset, Protocol.MaxMessageLength - TagSize);
+
+                var buffer = new byte[chunksize+TagSize];
+                var cipherBytes = transport.WriteMessage(new ReadOnlySpan<byte>(data, dataOffset, chunksize), buffer);
+
+                var prefix = BitConverter.GetBytes((UInt16)cipherBytes);
+                //We Want Big Endian
+                if (BitConverter.IsLittleEndian)
+                    Array.Reverse(prefix);
+
+                await stream.WriteAsync(prefix, 0, 2);
+
+                await stream.WriteAsync(buffer, 0, cipherBytes, cancel);
+
+                dataOffset += chunksize;
+            }
+
+            await stream.FlushAsync(cancel).ConfigureAwait(false);
+
+            log.Debug($"Sent via Noise {data.Length} bytes");
+        }
+
+        /// <inheritdoc />
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            outStream.Write(buffer, offset, count);
+        }
+
+        /// <inheritdoc />
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            return outStream.WriteAsync(buffer, offset, count, cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public override void WriteByte(byte value)
+        {
+            outStream.WriteByte(value);
+        }
+
+        /// <inheritdoc />
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                transport.Dispose();
+                stream.Dispose();
+                outStream.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/SecureCommunication/Noise/NoiseStream.cs
+++ b/src/SecureCommunication/Noise/NoiseStream.cs
@@ -152,9 +152,6 @@ namespace PeerTalk.SecureCommunication.Noise
             //Do that pesky decrypt thing
             var plaintextBytes = transport.ReadMessage(buffer, plaintextbuffer);
 
-
-            log.Debug($"Recieved via Noise {messageSize} bytes");
-
             //This is really inefficient but gets the job done
             return new ReadOnlySpan<byte>(plaintextbuffer, 0, plaintextBytes).ToArray();
         }
@@ -199,8 +196,6 @@ namespace PeerTalk.SecureCommunication.Noise
             }
 
             await stream.FlushAsync(cancel).ConfigureAwait(false);
-
-            log.Debug($"Sent via Noise {data.Length} bytes");
         }
 
         /// <inheritdoc />

--- a/src/Swarm.cs
+++ b/src/Swarm.cs
@@ -42,6 +42,7 @@ namespace PeerTalk
         List<IPeerProtocol> protocols = new List<IPeerProtocol>
         {
             new Multistream1(),
+            new SecureCommunication.Noise(),
             new SecureCommunication.Secio1(),
             new Identify1(),
             new Mplex67()

--- a/src/Swarm.cs
+++ b/src/Swarm.cs
@@ -42,7 +42,7 @@ namespace PeerTalk
         List<IPeerProtocol> protocols = new List<IPeerProtocol>
         {
             new Multistream1(),
-            new SecureCommunication.Noise(),
+            new SecureCommunication.Noise.Noise(),
             new SecureCommunication.Secio1(),
             new Identify1(),
             new Mplex67()


### PR DESCRIPTION
Also includes a refactor of the mplex implementation to better match the spec with regards to id numbers.

Known Issues:
* Incoming connections don't seem to negotiate noise for some reason
* It appears there may be some issues validating peers that use different (older?) id encodings

Mostly resolves #59

cc: @Pandapip1